### PR TITLE
Feature: Store 목록 조회 API 구현 close #23

### DIFF
--- a/src/main/java/com/example/smaap/domain/business/repository/StoreRepository.java
+++ b/src/main/java/com/example/smaap/domain/business/repository/StoreRepository.java
@@ -2,6 +2,7 @@ package com.example.smaap.domain.business.repository;
 
 import com.example.smaap.domain.business.entity.Store;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 
-public interface StoreRepository extends JpaRepository<Store, Long> {
+public interface StoreRepository extends JpaRepository<Store, Long>, QuerydslPredicateExecutor<Store> {
 }

--- a/src/main/java/com/example/smaap/domain/business/repository/StoreRepository.java
+++ b/src/main/java/com/example/smaap/domain/business/repository/StoreRepository.java
@@ -1,8 +1,17 @@
 package com.example.smaap.domain.business.repository;
 
 import com.example.smaap.domain.business.entity.Store;
+import com.querydsl.core.types.Predicate;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 
+import java.util.List;
+
+
 public interface StoreRepository extends JpaRepository<Store, Long>, QuerydslPredicateExecutor<Store> {
+    default List<Store> findAll(Predicate predicate, int size) {
+        return findAll((Predicate) predicate, (Pageable) PageRequest.of(0, size)).getContent();
+    }
 }

--- a/src/main/java/com/example/smaap/domain/business/repository/StoreRepository.java
+++ b/src/main/java/com/example/smaap/domain/business/repository/StoreRepository.java
@@ -1,0 +1,7 @@
+package com.example.smaap.domain.business.repository;
+
+import com.example.smaap.domain.business.entity.Store;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StoreRepository extends JpaRepository<Store, Long> {
+}

--- a/src/main/java/com/example/smaap/domain/business/service/StoreService.java
+++ b/src/main/java/com/example/smaap/domain/business/service/StoreService.java
@@ -15,7 +15,7 @@ import java.util.List;
 public class StoreService {
     private final StoreRepository storeRepository;
 
-    public List<Store> list(Long businessId, String address, BigDecimal latitude, BigDecimal longitude, Long range) {
+    public List<Store> list(Long businessId, String address, BigDecimal latitude, BigDecimal longitude, Long range, int size) {
         QStore qStore = QStore.store;
         BooleanBuilder builder = new BooleanBuilder();
 
@@ -28,17 +28,12 @@ public class StoreService {
                     .or(qStore.readNameAddress.containsIgnoreCase(address)));
         }
 
-        if (latitude != null && longitude != null && range != null) {
-            double rangeInDegree = range / 111.12;
-            double minLatitude = latitude.doubleValue() - rangeInDegree;
-            double maxLatitude = latitude.doubleValue() + rangeInDegree;
-            double minLongitude = longitude.doubleValue() - rangeInDegree;
-            double maxLongitude = longitude.doubleValue() + rangeInDegree;
-
-            builder.and(qStore.latitude.between(BigDecimal.valueOf(minLatitude), BigDecimal.valueOf(maxLatitude))
-                    .and(qStore.longitude.between(BigDecimal.valueOf(minLongitude), BigDecimal.valueOf(maxLongitude))));
+        if (latitude != null && longitude != null) {
+            BigDecimal rangeValue = BigDecimal.valueOf(range).divide(BigDecimal.valueOf(1000));
+            builder.and(qStore.latitude.between(latitude.subtract(rangeValue), latitude.add(rangeValue))
+                    .and(qStore.longitude.between(longitude.subtract(rangeValue), longitude.add(rangeValue))));
         }
 
-        return (List<Store>) storeRepository.findAll(builder);
+        return (List<Store>) storeRepository.findAll(builder, size);
     }
 }

--- a/src/main/java/com/example/smaap/domain/business/service/StoreService.java
+++ b/src/main/java/com/example/smaap/domain/business/service/StoreService.java
@@ -1,0 +1,44 @@
+package com.example.smaap.domain.business.service;
+
+import com.example.smaap.domain.business.entity.QStore;
+import com.example.smaap.domain.business.entity.Store;
+import com.example.smaap.domain.business.repository.StoreRepository;
+import com.querydsl.core.BooleanBuilder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class StoreService {
+    private final StoreRepository storeRepository;
+
+    public List<Store> list(Long businessId, String address, BigDecimal latitude, BigDecimal longitude, Long range) {
+        QStore qStore = QStore.store;
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (businessId != null) {
+            builder.and(qStore.business.id.eq(businessId));
+        }
+
+        if (address != null && !address.isEmpty()) {
+            builder.and(qStore.lotNumberAddress.containsIgnoreCase(address)
+                    .or(qStore.readNameAddress.containsIgnoreCase(address)));
+        }
+
+        if (latitude != null && longitude != null && range != null) {
+            double rangeInDegree = range / 111.12;
+            double minLatitude = latitude.doubleValue() - rangeInDegree;
+            double maxLatitude = latitude.doubleValue() + rangeInDegree;
+            double minLongitude = longitude.doubleValue() - rangeInDegree;
+            double maxLongitude = longitude.doubleValue() + rangeInDegree;
+
+            builder.and(qStore.latitude.between(BigDecimal.valueOf(minLatitude), BigDecimal.valueOf(maxLatitude))
+                    .and(qStore.longitude.between(BigDecimal.valueOf(minLongitude), BigDecimal.valueOf(maxLongitude))));
+        }
+
+        return (List<Store>) storeRepository.findAll(builder);
+    }
+}

--- a/src/main/java/com/example/smaap/presentation/rest/StoreController.java
+++ b/src/main/java/com/example/smaap/presentation/rest/StoreController.java
@@ -1,0 +1,34 @@
+package com.example.smaap.presentation.rest;
+
+import com.example.smaap.domain.business.service.StoreService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.math.BigDecimal;
+
+@RestController
+@RequestMapping("/stores")
+@Tag(name = "Store", description = "상점 정보 API")
+@RequiredArgsConstructor
+public class StoreController {
+    private final StoreService storeService;
+
+    @GetMapping
+    @Operation(summary = "상점 목록 조회", description = "상점 목록을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "상점 목록 조회 성공")
+    public ResponseEntity<?> list(@RequestParam(required = false) Long businessId,
+                                  @RequestParam(required = false) String address,
+                                  @RequestParam(required = false) BigDecimal latitude,
+                                  @RequestParam(required = false) BigDecimal longitude,
+                                  @RequestParam(defaultValue = "1000") Long range,
+                                  @RequestParam(defaultValue = "100") int size) {
+        return ResponseEntity.ok(storeService.list(businessId, address, latitude, longitude, range, size));
+    }
+}


### PR DESCRIPTION
## Motivation

<!-- 작성 배경 -->

- #23 참고

## Problem Solving

<!-- 해결 방법 -->

- 업종별 필터링
- 주소 문자열 필터링
- 위도/경도, 범위 필터링
- 최대 조회 개수(100개) 설정

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->

<img width="341" alt="image" src="https://github.com/user-attachments/assets/3219474e-f63e-4568-a049-f8dbe39bba22">

- 현재 데이터베이스에 저장되어 있는 상점의 개수가 10만개를 넘어서다 보니 모든 조건을 설정하지 않고(default) API 요청 시 요청->응답까지 오랜 시간(~~체감 상 1분이상 걸리는 것 같네요...~~, Postman으로 실행 시 17.75초 걸립니다.) 걸리다보니 최대 개수를 API에서 설정할 수 있도록 구현하였습니다. 현재는 100개 입니다.