### PR TITLE
Feature: 인기 상권 목록 조회 API 구현 close #33

### DIFF
--- a/src/main/java/com/example/smaap/domain/region/repository/NeighborhoodRepository.java
+++ b/src/main/java/com/example/smaap/domain/region/repository/NeighborhoodRepository.java
@@ -1,22 +1,11 @@
 package com.example.smaap.domain.region.repository;
 
 import com.example.smaap.domain.region.entity.Neighborhood;
-import com.example.smaap.presentation.dto.NeighborhoodCountDTO;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 
 import java.util.List;
 
-public interface NeighborhoodRepository extends JpaRepository<Neighborhood, Long> {
+public interface NeighborhoodRepository extends JpaRepository<Neighborhood, Long>, QuerydslPredicateExecutor<Neighborhood> {
     List<Neighborhood> findAllByDistrictId(Long districtId);
-
-    @Query(
-            "SELECT new com.example.smaap.presentation.dto.NeighborhoodCountDTO.Response(" +
-                    "n.id, n.name, COUNT(s.id)) " +
-                    "FROM Neighborhood n " +
-                    "LEFT JOIN n.district s " + // n.district -> n.stopres로 수정 필요
-                    "GROUP BY n.id, n.name " +
-                    "ORDER BY COUNT(s.id) DESC"
-    )
-    List<NeighborhoodCountDTO.Response> findAllByStoreCountDesc();
 }

--- a/src/main/java/com/example/smaap/domain/region/repository/NeighborhoodRepository.java
+++ b/src/main/java/com/example/smaap/domain/region/repository/NeighborhoodRepository.java
@@ -1,10 +1,22 @@
 package com.example.smaap.domain.region.repository;
 
 import com.example.smaap.domain.region.entity.Neighborhood;
+import com.example.smaap.presentation.dto.NeighborhoodCountDTO;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface NeighborhoodRepository extends JpaRepository<Neighborhood, Long> {
     List<Neighborhood> findAllByDistrictId(Long districtId);
+
+    @Query(
+            "SELECT new com.example.smaap.presentation.dto.NeighborhoodCountDTO.Response(" +
+                    "n.id, n.name, COUNT(s.id)) " +
+                    "FROM Neighborhood n " +
+                    "LEFT JOIN n.district s " + // n.district -> n.stopres로 수정 필요
+                    "GROUP BY n.id, n.name " +
+                    "ORDER BY COUNT(s.id) DESC"
+    )
+    List<NeighborhoodCountDTO.Response> findAllByStoreCountDesc();
 }

--- a/src/main/java/com/example/smaap/domain/region/service/NeighborhoodService.java
+++ b/src/main/java/com/example/smaap/domain/region/service/NeighborhoodService.java
@@ -6,6 +6,7 @@ import com.example.smaap.domain.population.type.PopulationType;
 import com.example.smaap.domain.region.entity.Neighborhood;
 import com.example.smaap.domain.region.entity.QNeighborhood;
 import com.example.smaap.domain.region.repository.NeighborhoodRepository;
+import com.example.smaap.domain.region.type.PopularType;
 import com.example.smaap.presentation.dto.NeighborhoodCountDTO;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.NumberExpression;
@@ -30,17 +31,17 @@ public class NeighborhoodService {
         return neighborhoodRepository.findAllByDistrictId(districtId);
     }
 
-    public List<NeighborhoodCountDTO.Response> list(String popularType) {
-        switch (popularType) {
-            case "store":
+    public List<NeighborhoodCountDTO.Response> list(PopularType type, Long count) {
+        switch (type) {
+            case STORE:
 //                return findAllByStoreCount();
                 throw new IllegalArgumentException("잘못된 정렬 기준입니다.");
-            case "sales":
-                return findAllBySales();
-            case "floating":
-                return findAllByFloatingPopulation();
-            case "resident":
-                return findAllByResidentPopulation();
+            case SALES:
+                return findAllBySales(count);
+            case FLOATING:
+                return findAllByFloatingPopulation(count);
+            case RESIDENT:
+                return findAllByResidentPopulation(count);
             default:
                 throw new IllegalArgumentException("잘못된 정렬 기준입니다.");
         }
@@ -68,7 +69,7 @@ public class NeighborhoodService {
 //                .fetch();
 //    }
 
-    private List<NeighborhoodCountDTO.Response> findAllBySales() {
+    private List<NeighborhoodCountDTO.Response> findAllBySales(Long count) {
         QNeighborhood neighborhood = QNeighborhood.neighborhood;
         QCardPayment sales = QCardPayment.cardPayment;
 
@@ -82,10 +83,11 @@ public class NeighborhoodService {
                 .on(sales.neighborhood.id.eq(neighborhood.id))
                 .groupBy(neighborhood.id, neighborhood.name)
                 .orderBy(sales.totalAmount.sum().desc())
+                .limit(count)
                 .fetch();
     }
 
-    private List<NeighborhoodCountDTO.Response> findAllByFloatingPopulation() {
+    private List<NeighborhoodCountDTO.Response> findAllByFloatingPopulation(Long count) {
         QNeighborhood neighborhood = QNeighborhood.neighborhood;
         QPopulation population = QPopulation.population;
 
@@ -125,10 +127,11 @@ public class NeighborhoodService {
                 .where(population.type.in(PopulationType.WORK, PopulationType.VISIT))
                 .groupBy(neighborhood.id, neighborhood.name)
                 .orderBy(sumAllHours.sum().desc())
+                .limit(count)
                 .fetch();
     }
 
-    private List<NeighborhoodCountDTO.Response> findAllByFloatingPopulation() {
+    private List<NeighborhoodCountDTO.Response> findAllByResidentPopulation(Long count) {
         QNeighborhood neighborhood = QNeighborhood.neighborhood;
         QPopulation population = QPopulation.population;
 
@@ -168,6 +171,7 @@ public class NeighborhoodService {
                 .where(population.type.in(PopulationType.HOME))
                 .groupBy(neighborhood.id, neighborhood.name)
                 .orderBy(sumAllHours.sum().desc())
+                .limit(count)
                 .fetch();
     }
 

--- a/src/main/java/com/example/smaap/domain/region/service/NeighborhoodService.java
+++ b/src/main/java/com/example/smaap/domain/region/service/NeighborhoodService.java
@@ -2,6 +2,7 @@ package com.example.smaap.domain.region.service;
 
 import com.example.smaap.domain.region.entity.Neighborhood;
 import com.example.smaap.domain.region.repository.NeighborhoodRepository;
+import com.example.smaap.presentation.dto.NeighborhoodCountDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -18,6 +19,15 @@ public class NeighborhoodService {
 
     public List<Neighborhood> list(Long districtId) {
         return neighborhoodRepository.findAllByDistrictId(districtId);
+    }
+
+    public List<NeighborhoodCountDTO.Response> list(String popularType) {
+        // 점포 수
+        return neighborhoodRepository.findAllByStoreCountDesc();
+
+        // 매출액
+        // 유동 인구 수
+        // 거주 인구 수
     }
 
     public Neighborhood read(Long id) {

--- a/src/main/java/com/example/smaap/domain/region/service/NeighborhoodService.java
+++ b/src/main/java/com/example/smaap/domain/region/service/NeighborhoodService.java
@@ -2,15 +2,18 @@ package com.example.smaap.domain.region.service;
 
 import com.example.smaap.domain.payment.entity.QCardPayment;
 import com.example.smaap.domain.population.entity.QPopulation;
+import com.example.smaap.domain.population.type.PopulationType;
 import com.example.smaap.domain.region.entity.Neighborhood;
 import com.example.smaap.domain.region.entity.QNeighborhood;
 import com.example.smaap.domain.region.repository.NeighborhoodRepository;
 import com.example.smaap.presentation.dto.NeighborhoodCountDTO;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 @Service
@@ -86,31 +89,85 @@ public class NeighborhoodService {
         QNeighborhood neighborhood = QNeighborhood.neighborhood;
         QPopulation population = QPopulation.population;
 
+        NumberExpression<BigDecimal> sumAllHours = population.population00
+                .add(population.population01)
+                .add(population.population02)
+                .add(population.population03)
+                .add(population.population04)
+                .add(population.population05)
+                .add(population.population06)
+                .add(population.population07)
+                .add(population.population08)
+                .add(population.population09)
+                .add(population.population10)
+                .add(population.population11)
+                .add(population.population12)
+                .add(population.population13)
+                .add(population.population14)
+                .add(population.population15)
+                .add(population.population16)
+                .add(population.population17)
+                .add(population.population18)
+                .add(population.population19)
+                .add(population.population20)
+                .add(population.population21)
+                .add(population.population22)
+                .add(population.population23);
+
         return queryFactory
                 .select(Projections.constructor(NeighborhoodCountDTO.Response.class,
                         neighborhood.id,
                         neighborhood.name,
-                        population.floatingCount))
+                        sumAllHours.sum()))
                 .from(neighborhood)
                 .leftJoin(population)
                 .on(population.neighborhood.id.eq(neighborhood.id))
-                .orderBy(population.floatingCount.desc())
+                .where(population.type.in(PopulationType.WORK, PopulationType.VISIT))
+                .groupBy(neighborhood.id, neighborhood.name)
+                .orderBy(sumAllHours.sum().desc())
                 .fetch();
     }
 
-    private List<NeighborhoodCountDTO.Response> findAllByResidentPopulation() {
+    private List<NeighborhoodCountDTO.Response> findAllByFloatingPopulation() {
         QNeighborhood neighborhood = QNeighborhood.neighborhood;
         QPopulation population = QPopulation.population;
+
+        NumberExpression<BigDecimal> sumAllHours = population.population00
+                .add(population.population01)
+                .add(population.population02)
+                .add(population.population03)
+                .add(population.population04)
+                .add(population.population05)
+                .add(population.population06)
+                .add(population.population07)
+                .add(population.population08)
+                .add(population.population09)
+                .add(population.population10)
+                .add(population.population11)
+                .add(population.population12)
+                .add(population.population13)
+                .add(population.population14)
+                .add(population.population15)
+                .add(population.population16)
+                .add(population.population17)
+                .add(population.population18)
+                .add(population.population19)
+                .add(population.population20)
+                .add(population.population21)
+                .add(population.population22)
+                .add(population.population23);
 
         return queryFactory
                 .select(Projections.constructor(NeighborhoodCountDTO.Response.class,
                         neighborhood.id,
                         neighborhood.name,
-                        population.residentCount))
+                        sumAllHours.sum()))
                 .from(neighborhood)
                 .leftJoin(population)
                 .on(population.neighborhood.id.eq(neighborhood.id))
-                .orderBy(population.residentCount.desc())
+                .where(population.type.in(PopulationType.HOME))
+                .groupBy(neighborhood.id, neighborhood.name)
+                .orderBy(sumAllHours.sum().desc())
                 .fetch();
     }
 

--- a/src/main/java/com/example/smaap/domain/region/service/NeighborhoodService.java
+++ b/src/main/java/com/example/smaap/domain/region/service/NeighborhoodService.java
@@ -1,8 +1,13 @@
 package com.example.smaap.domain.region.service;
 
+import com.example.smaap.domain.payment.entity.QCardPayment;
+import com.example.smaap.domain.population.entity.QPopulation;
 import com.example.smaap.domain.region.entity.Neighborhood;
+import com.example.smaap.domain.region.entity.QNeighborhood;
 import com.example.smaap.domain.region.repository.NeighborhoodRepository;
 import com.example.smaap.presentation.dto.NeighborhoodCountDTO;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -12,6 +17,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class NeighborhoodService {
     private final NeighborhoodRepository neighborhoodRepository;
+    private final JPAQueryFactory queryFactory;
 
     public List<Neighborhood> list() {
         return neighborhoodRepository.findAll();
@@ -22,16 +28,90 @@ public class NeighborhoodService {
     }
 
     public List<NeighborhoodCountDTO.Response> list(String popularType) {
-        // 점포 수
-        return neighborhoodRepository.findAllByStoreCountDesc();
-
-        // 매출액
-        // 유동 인구 수
-        // 거주 인구 수
+        switch (popularType) {
+            case "store":
+//                return findAllByStoreCount();
+                throw new IllegalArgumentException("잘못된 정렬 기준입니다.");
+            case "sales":
+                return findAllBySales();
+            case "floating":
+                return findAllByFloatingPopulation();
+            case "resident":
+                return findAllByResidentPopulation();
+            default:
+                throw new IllegalArgumentException("잘못된 정렬 기준입니다.");
+        }
     }
 
     public Neighborhood read(Long id) {
         return neighborhoodRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 동입니다."));
     }
+
+//    private List<NeighborhoodCountDTO.Response> findAllByStoreCount() {
+//        QNeighborhood neighborhood = QNeighborhood.neighborhood;
+//        QStore store = QStore.store;
+//
+//        return queryFactory
+//                .select(Projections.constructor(NeighborhoodCountDTO.Response.class,
+//                        neighborhood.id,
+//                        neighborhood.name,
+//                        store.count()))
+//                .from(neighborhood)
+//                .leftJoin(store)
+//                .on(store.neighborhood.id.eq(neighborhood.id))
+//                .groupBy(neighborhood.id, neighborhood.name)
+//                .orderBy(store.count().desc())
+//                .fetch();
+//    }
+
+    private List<NeighborhoodCountDTO.Response> findAllBySales() {
+        QNeighborhood neighborhood = QNeighborhood.neighborhood;
+        QCardPayment sales = QCardPayment.cardPayment;
+
+        return queryFactory
+                .select(Projections.constructor(NeighborhoodCountDTO.Response.class,
+                        neighborhood.id,
+                        neighborhood.name,
+                        sales.totalAmount.sum()))
+                .from(neighborhood)
+                .leftJoin(sales)
+                .on(sales.neighborhood.id.eq(neighborhood.id))
+                .groupBy(neighborhood.id, neighborhood.name)
+                .orderBy(sales.totalAmount.sum().desc())
+                .fetch();
+    }
+
+    private List<NeighborhoodCountDTO.Response> findAllByFloatingPopulation() {
+        QNeighborhood neighborhood = QNeighborhood.neighborhood;
+        QPopulation population = QPopulation.population;
+
+        return queryFactory
+                .select(Projections.constructor(NeighborhoodCountDTO.Response.class,
+                        neighborhood.id,
+                        neighborhood.name,
+                        population.floatingCount))
+                .from(neighborhood)
+                .leftJoin(population)
+                .on(population.neighborhood.id.eq(neighborhood.id))
+                .orderBy(population.floatingCount.desc())
+                .fetch();
+    }
+
+    private List<NeighborhoodCountDTO.Response> findAllByResidentPopulation() {
+        QNeighborhood neighborhood = QNeighborhood.neighborhood;
+        QPopulation population = QPopulation.population;
+
+        return queryFactory
+                .select(Projections.constructor(NeighborhoodCountDTO.Response.class,
+                        neighborhood.id,
+                        neighborhood.name,
+                        population.residentCount))
+                .from(neighborhood)
+                .leftJoin(population)
+                .on(population.neighborhood.id.eq(neighborhood.id))
+                .orderBy(population.residentCount.desc())
+                .fetch();
+    }
+
 }

--- a/src/main/java/com/example/smaap/domain/region/type/PopularType.java
+++ b/src/main/java/com/example/smaap/domain/region/type/PopularType.java
@@ -1,0 +1,5 @@
+package com.example.smaap.domain.region.type;
+
+public enum PopularType {
+    STORE, SALES, FLOATING, RESIDENT
+}

--- a/src/main/java/com/example/smaap/infrastructure/config/QuerydslConfig.java
+++ b/src/main/java/com/example/smaap/infrastructure/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package com.example.smaap.infrastructure.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/example/smaap/presentation/dto/NeighborhoodCountDTO.java
+++ b/src/main/java/com/example/smaap/presentation/dto/NeighborhoodCountDTO.java
@@ -1,0 +1,28 @@
+package com.example.smaap.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+public class NeighborhoodCountDTO {
+    @Getter
+    @Schema(name = "NeighborhoodStoreCount.Response", description = "동별 점포 수 응답 DTO")
+    public static class Response {
+        @Schema(description = "동 고유번호", example = "1")
+        private Long id;
+
+        @Schema(description = "동 이름", example = "삼성동")
+        private String name;
+
+        @Schema(description = "값", example = "100")
+        private Long count;
+
+        @Builder
+        public Response(Long id, String name, Long storeCount) {
+            this.id = id;
+            this.name = name;
+            this.count = storeCount;
+        }
+    }
+}
+

--- a/src/main/java/com/example/smaap/presentation/rest/NeighborhoodController.java
+++ b/src/main/java/com/example/smaap/presentation/rest/NeighborhoodController.java
@@ -1,0 +1,26 @@
+package com.example.smaap.presentation.rest;
+
+import com.example.smaap.domain.region.service.NeighborhoodService;
+import com.example.smaap.domain.region.type.PopularType;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/neighborhoods")
+@Tag(name = "Neiborhoods", description = "동 정보 API")
+@RequiredArgsConstructor
+public class NeighborhoodController {
+    private final NeighborhoodService neighborhoodService;
+
+    @GetMapping("")
+    @Operation(summary = "인기 상권 조회", description = "인기 상권을 조회합니다.")
+    public ResponseEntity<?> list(@RequestParam PopularType type, @RequestParam(defaultValue = "5") Long count) {
+        return ResponseEntity.ok(neighborhoodService.list(type, count));
+    }
+}


### PR DESCRIPTION
## Motivation

<!-- 작성 배경 -->

- #33 참고

## Problem Solving

<!-- 해결 방법 -->

- 매출액이 많은 상권 조회 로직 구현
- 유동 인구가 많은 상권 조회 로직 구현
- 거주 인구가 많은 상권 조회 로직 구현
- QueryDSL Config 파일 작성

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->

- 점포 수에 따른 인기 상권 조회 난항
  <img width="802" alt="image" src="https://github.com/user-attachments/assets/6be45f88-49f0-4f08-975e-f552f37bb74d">

  - 현재 `store` 테이블에는 '동'에 관련된 정보가 '지번주소', '도로명주소'에 문자열의 일부로만 저장되고 있는 형태
  - 따라서 `neighborhood` 테이블과 연결되어 있지 않아, 처리 방식을 결정하지 못하여 현재 예외 처리 하였음
