### PR TITLE
Feature: 동별 유망 업종 추천 API 구현 close #34

### DIFF
--- a/src/main/java/com/example/smaap/domain/business/service/StoreService.java
+++ b/src/main/java/com/example/smaap/domain/business/service/StoreService.java
@@ -36,4 +36,9 @@ public class StoreService {
 
         return (List<Store>) storeRepository.findAll(builder, size);
     }
+
+    public List<Store> list(String neighborhoodName) {
+        return storeRepository.findAll().stream().filter(s -> s.getLotNumberAddress().contains(neighborhoodName))
+                .toList();
+    }
 }

--- a/src/main/java/com/example/smaap/presentation/dto/RecommendedBusinessDto.java
+++ b/src/main/java/com/example/smaap/presentation/dto/RecommendedBusinessDto.java
@@ -1,0 +1,26 @@
+package com.example.smaap.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class RecommendedBusinessDto {
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(name = "RecommendedBusiness.Response", description = "유망 상권 응답 DTO")
+    public static class Response {
+        @Schema(description = "업종 고유번호", example = "1")
+        private Long id;
+
+        @Schema(description = "업종명", example = "요식업")
+        private String name;
+        @Schema(description = "비율", example = "29")
+        private Double percent;
+
+        public static Response of(Long id, String name, Double percent) {
+            return new Response(id, name, percent);
+        }
+    }
+}

--- a/src/main/java/com/example/smaap/presentation/rest/NeighborhoodController.java
+++ b/src/main/java/com/example/smaap/presentation/rest/NeighborhoodController.java
@@ -6,10 +6,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/neighborhoods")
@@ -22,5 +19,11 @@ public class NeighborhoodController {
     @Operation(summary = "인기 상권 조회", description = "인기 상권을 조회합니다.")
     public ResponseEntity<?> list(@RequestParam PopularType type, @RequestParam(defaultValue = "5") Long count) {
         return ResponseEntity.ok(neighborhoodService.list(type, count));
+    }
+
+    @GetMapping("/{id}/recommended-businesses")
+    @Operation(summary = "유망 상권 조회", description = "유망 상권을 조회합니다.")
+    public ResponseEntity<?> recommendedBusinesses(@PathVariable Long id) {
+        return ResponseEntity.ok(neighborhoodService.recommendedBusinesses(id));
     }
 }


### PR DESCRIPTION
## Motivation

<!-- 작성 배경 -->

- #34 

## Problem Solving

<!-- 해결 방법 -->

- ID를 파라미터로 받아 배열 형태로 id, name, percent를 반환하도록 구현 (아래 예시 참고)
  ```json
  [
	  {
	    "id": 2,
	    "name": "서비스업",
	    "percent": 44.26855895196506
	  },
	  {
	    "id": 1,
	    "name": "요식업",
	    "percent": 29.203056768558948
	  },
	  {
	    "id": 3,
	    "name": "소매업",
	    "percent": 13.318777292576419
	  },
	  {
	    "id": 4,
	    "name": "교육서비스업",
	    "percent": 13.209606986899564
	  }
  ]
  ```

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->

- #37 와 동일하게 `store` 테이블에 neighborhood_id가 없어 store의 지번 주소 문자열을 참고하여 조회하도록 구현하였습니다.
- 이로 인해 API 응답 속도가 느립니다. (Postman에서 요청해보니 4.5초 정도 걸리네요...) 추후 성능 개선이 필요할 것으로 보입니다.
  
  <img width="1289" alt="image" src="https://github.com/user-attachments/assets/fba45d51-f8b5-4527-b9bd-a4701f7cb240">
