### PR TITLE
Fix: 인기 상권 목록 조회 API 오류 해결 #45

### DIFF
--- a/src/main/java/com/example/smaap/domain/region/service/NeighborhoodService.java
+++ b/src/main/java/com/example/smaap/domain/region/service/NeighborhoodService.java
@@ -1,6 +1,7 @@
 package com.example.smaap.domain.region.service;
 
 import com.example.smaap.domain.business.entity.Business;
+import com.example.smaap.domain.business.entity.QStore;
 import com.example.smaap.domain.business.entity.Store;
 import com.example.smaap.domain.business.service.StoreService;
 import com.example.smaap.domain.payment.entity.QCardPayment;
@@ -40,19 +41,13 @@ public class NeighborhoodService {
     }
 
     public List<NeighborhoodCountDTO.Response> list(PopularType type, Long count) {
-        switch (type) {
-            case STORE:
-//                return findAllByStoreCount();
-                throw new IllegalArgumentException("잘못된 정렬 기준입니다.");
-            case SALES:
-                return findAllBySales(count);
-            case FLOATING:
-                return findAllByFloatingPopulation(count);
-            case RESIDENT:
-                return findAllByResidentPopulation(count);
-            default:
-                throw new IllegalArgumentException("잘못된 정렬 기준입니다.");
-        }
+        return switch (type) {
+            case STORE -> findAllByStoreCount(count);
+            case SALES -> findAllBySales(count);
+            case FLOATING -> findAllByFloatingPopulation(count);
+            case RESIDENT -> findAllByResidentPopulation(count);
+            default -> throw new IllegalArgumentException("잘못된 정렬 기준입니다.");
+        };
     }
 
     public Neighborhood read(Long id) {
@@ -81,22 +76,23 @@ public class NeighborhoodService {
                 .collect(Collectors.toList());
     }
 
-//    private List<NeighborhoodCountDTO.Response> findAllByStoreCount() {
-//        QNeighborhood neighborhood = QNeighborhood.neighborhood;
-//        QStore store = QStore.store;
-//
-//        return queryFactory
-//                .select(Projections.constructor(NeighborhoodCountDTO.Response.class,
-//                        neighborhood.id,
-//                        neighborhood.name,
-//                        store.count()))
-//                .from(neighborhood)
-//                .leftJoin(store)
-//                .on(store.neighborhood.id.eq(neighborhood.id))
-//                .groupBy(neighborhood.id, neighborhood.name)
-//                .orderBy(store.count().desc())
-//                .fetch();
-//    }
+    private List<NeighborhoodCountDTO.Response> findAllByStoreCount(Long count) {
+        QNeighborhood neighborhood = QNeighborhood.neighborhood;
+        QStore store = QStore.store;
+
+        return queryFactory
+                .select(Projections.constructor(NeighborhoodCountDTO.Response.class,
+                        neighborhood.id,
+                        neighborhood.name,
+                        store.count()))
+                .from(neighborhood)
+                .leftJoin(store)
+                .on(store.neighborhood.id.eq(neighborhood.id))
+                .groupBy(neighborhood.id, neighborhood.name)
+                .orderBy(store.count().desc())
+                .limit(count)
+                .fetch();
+    }
 
     private List<NeighborhoodCountDTO.Response> findAllBySales(Long count) {
         QNeighborhood neighborhood = QNeighborhood.neighborhood;

--- a/src/main/java/com/example/smaap/domain/region/service/NeighborhoodService.java
+++ b/src/main/java/com/example/smaap/domain/region/service/NeighborhoodService.java
@@ -149,7 +149,7 @@ public class NeighborhoodService {
                 .select(Projections.constructor(NeighborhoodCountDTO.Response.class,
                         neighborhood.id,
                         neighborhood.name,
-                        sumAllHours.sum()))
+                        sumAllHours.sum().longValue()))
                 .from(neighborhood)
                 .leftJoin(population)
                 .on(population.neighborhood.id.eq(neighborhood.id))
@@ -193,7 +193,7 @@ public class NeighborhoodService {
                 .select(Projections.constructor(NeighborhoodCountDTO.Response.class,
                         neighborhood.id,
                         neighborhood.name,
-                        sumAllHours.sum()))
+                        sumAllHours.sum().longValue()))
                 .from(neighborhood)
                 .leftJoin(population)
                 .on(population.neighborhood.id.eq(neighborhood.id))

--- a/src/main/java/com/example/smaap/domain/region/type/PopularType.java
+++ b/src/main/java/com/example/smaap/domain/region/type/PopularType.java
@@ -1,5 +1,8 @@
 package com.example.smaap.domain.region.type;
 
 public enum PopularType {
-    STORE, SALES, FLOATING, RESIDENT
+    STORE,  // 상점 수
+    SALES,  // 매출액
+    FLOATING,   // 유동인구
+    RESIDENT    // 주거인구
 }

--- a/src/main/java/com/example/smaap/presentation/rest/NeighborhoodController.java
+++ b/src/main/java/com/example/smaap/presentation/rest/NeighborhoodController.java
@@ -16,7 +16,7 @@ public class NeighborhoodController {
     private final NeighborhoodService neighborhoodService;
 
     @GetMapping("")
-    @Operation(summary = "인기 상권 조회", description = "인기 상권을 조회합니다.")
+    @Operation(summary = "인기 상권 조회", description = "조건(PopularType)에 따른 인기 상권(동)을 조회합니다.")
     public ResponseEntity<?> list(@RequestParam PopularType type, @RequestParam(defaultValue = "5") Long count) {
         return ResponseEntity.ok(neighborhoodService.list(type, count));
     }

--- a/src/main/java/com/example/smaap/presentation/rest/NeighborhoodController.java
+++ b/src/main/java/com/example/smaap/presentation/rest/NeighborhoodController.java
@@ -3,6 +3,7 @@ package com.example.smaap.presentation.rest;
 import com.example.smaap.domain.region.service.NeighborhoodService;
 import com.example.smaap.domain.region.type.PopularType;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,8 +17,8 @@ public class NeighborhoodController {
     private final NeighborhoodService neighborhoodService;
 
     @GetMapping("")
-    @Operation(summary = "인기 상권 조회", description = "조건(PopularType)에 따른 인기 상권(동)을 조회합니다.")
-    public ResponseEntity<?> list(@RequestParam PopularType type, @RequestParam(defaultValue = "5") Long count) {
+    @Operation(summary = "인기 상권 조회", description = "조건(PopularType[STORE: 상점 수, SALES: 매출액, FLOATING: 유동인구, RESIDENT: 주거인구])에 따른 인기 상권(동)을 조회합니다.")
+    public ResponseEntity<?> list(@Parameter(description = "조회할 상권 타입") @RequestParam PopularType type, @RequestParam(defaultValue = "5") Long count) {
         return ResponseEntity.ok(neighborhoodService.list(type, count));
     }
 

--- a/src/main/java/com/example/smaap/presentation/rest/NeighborhoodController.java
+++ b/src/main/java/com/example/smaap/presentation/rest/NeighborhoodController.java
@@ -22,7 +22,7 @@ public class NeighborhoodController {
     }
 
     @GetMapping("/{id}/recommended-businesses")
-    @Operation(summary = "유망 상권 조회", description = "유망 상권을 조회합니다.")
+    @Operation(summary = "상권(동)에 따른 업종 조회", description = "상권(동)에 따른 추천 업종을 조회합니다.")
     public ResponseEntity<?> recommendedBusinesses(@PathVariable Long id) {
         return ResponseEntity.ok(neighborhoodService.recommendedBusinesses(id));
     }


### PR DESCRIPTION
## Motivation

<!-- 작성 배경 -->

- #45 참고

## Problem Solving

<!-- 해결 방법 -->

### 1. FLOATING & RESIDENT 요청 시 TypeError 해결

참고 : 8935bee1aea17ce3cfa171b64dda55970ead6fd8

| 기존 (Expression Exception) | 수정 후 (정상 동작) |
| --- | --- |
| <img width="300" alt="image" src="https://github.com/user-attachments/assets/aac3e778-3462-4930-a951-c6b12ed983f9"> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/106c8531-2837-4da4-8a0d-1f08acbaf31b"> |

ExpressionException이 발생하는 경위는 API Response Body를 반환하기 위해 생성한 DTO의 생성자 오류입니다. 상세 원인은 생활인구 합계(BigDecimal)와 DTO의 count 필드(Long)의 타입이 달라서 발생하는 오류이고, 생활인구 합계를 Long으로 변환함으로써 해결하였습니다.

### 2. 점포 수 목록 조회 기능 구현

참고 : 7e5866bcc5a8a29c163bf69745cd0c254f2eac8a

| 기존 | 수정 후 (정상 동작) |
| --- | --- |
| <img width="300" alt="image" src="https://github.com/user-attachments/assets/1eee6be1-a62f-44a9-90ca-ec2493433e1d"> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/dfd473dc-9edc-40b5-a553-9d57753d7ec8"> |

이전에 Store Entity에 Neighborhood에 대한 연관 관계를 설정하지 않아 추후 설정하기로 결정함에 따라, 이를 위해 예외처리 했던 부분을 구현하였습니다. (#37 참고)

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->

- X